### PR TITLE
隐藏后停止动画，开放暂停恢复方法

### DIFF
--- a/dayu_widgets/loading.py
+++ b/dayu_widgets/loading.py
@@ -71,6 +71,26 @@ class MLoading(QtWidgets.QWidget):
         painter.end()
         return super(MLoading, self).paintEvent(event)
 
+    def start(self):
+        self._loading_ani.start()
+
+    def resume(self):
+        self._loading_ani.resume()
+
+    def pause(self):
+        self._loading_ani.pause()
+
+    def stop(self):
+        self._loading_ani.stop()
+
+    def hideEvent(self, event):
+        self._loading_ani.stop()
+        super(MLoading, self).hideEvent(event)
+
+    def showEvent(self, event):
+        self._loading_ani.start()
+        super(MLoading, self).showEvent(event)
+
     @classmethod
     def huge(cls, color=None):
         """Create a MLoading with huge size"""


### PR DESCRIPTION
在布局中如果使用重复创建loading会增加代码复杂性，所以我用隐藏显示的方式控制loading图标
loading在隐藏之后动画一直不需要一直运行，所以有此提交