### PR TITLE
Feature/add cli entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 </p>
 
 
@@ -149,12 +149,33 @@ Components for PySide
 ![pageres](screenshots/divider_light.png)![pageres](screenshots/divider_dark.png)
 
 
+# 使用方法
+
+## 安装
+
+```shell
+pip install dayu_widgets
+```
+
+## 运行示例程序
+
+安装后，可以通过以下命令直接运行示例程序：
+
+```shell
+# 使用 Python 模块方式运行
+python -m dayu_widgets
+
+# 或者使用命令行工具运行
+uvx dayu_widgets
+```
+
 # 如何贡献代码
 
 ## 安装poetry
-``shell
+```shell
 pip install poetry
-``
+```
+
 ## 安装依赖
 ```shell
 poetry install
@@ -169,6 +190,7 @@ poetry run pytest
 ```shell
 poetry run black dayu_widgets
 ```
+
 ## 运行isort
 ```shell
 poetry run isort dayu_widgets

--- a/README.md
+++ b/README.md
@@ -159,15 +159,17 @@ pip install dayu_widgets
 
 ## 运行示例程序
 
-安装后，可以通过以下命令直接运行示例程序：
+安装后，可以通过以下命令直接运行示例程序。注意，运行示例程序需要 Qt 环境（如 PySide2 或 PyQt5）：
 
 ```shell
-# 使用 Python 模块方式运行
+# 使用 Python 模块方式运行（需要先安装 PySide2 或 PyQt5）
 python -m dayu_widgets
 
-# 或者使用命令行工具运行
-uvx dayu_widgets
+# 使用 uvx 命令行工具运行（推荐方式，自动处理依赖）
+uvx --python 3.10 --with pyside2 dayu_widgets
 ```
+
+> **注意**：dayu_widgets 是一个 Qt 界面库，运行示例程序需要 Qt 环境。使用 `uvx` 命令时可以通过 `--with pyside2` 参数自动处理 Qt 依赖。
 
 # 如何贡献代码
 

--- a/dayu_widgets/__main__.py
+++ b/dayu_widgets/__main__.py
@@ -7,11 +7,7 @@ from __future__ import print_function
 # Import built-in modules
 import os
 import sys
-import importlib
 import signal
-
-# Import third-party modules
-from Qt import QtWidgets
 
 
 def main():
@@ -20,23 +16,54 @@ def main():
     This function runs the demo application.
     """
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    
+
     # Add the parent directory to sys.path to ensure examples can be imported
     parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     if parent_dir not in sys.path:
         sys.path.insert(0, parent_dir)
-    
-    # Import the demo module
+
+    # Try different import strategies to find the demo module
     try:
+        # First try: direct import (when installed as a package with examples included)
         from examples.demo import MDemo
     except ImportError:
-        print("Error: Could not import the demo module. Make sure the examples directory is available.")
-        sys.exit(1)
-    
+        try:
+            # Second try: import from package (when examples is inside the package)
+            from dayu_widgets.examples.demo import MDemo
+        except ImportError:
+            # Third try: look for examples in common locations
+            examples_paths = [
+                # Current directory
+                os.path.join(os.getcwd(), 'examples'),
+                # Parent directory of the package
+                os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'examples'),
+                # Inside the package
+                os.path.join(os.path.dirname(os.path.abspath(__file__)), 'examples'),
+            ]
+
+            found = False
+            for path in examples_paths:
+                if os.path.exists(os.path.join(path, 'demo.py')):
+                    if path not in sys.path:
+                        sys.path.insert(0, os.path.dirname(path))
+                    try:
+                        from examples.demo import MDemo
+                        found = True
+                        break
+                    except ImportError:
+                        continue
+
+            if not found:
+                print("Error: Could not import the demo module. Make sure the examples directory is available.")
+                print("Searched in the following locations:")
+                for path in examples_paths:
+                    print(f"  - {path}")
+                sys.exit(1)
+
     # Import local modules
     from dayu_widgets import dayu_theme
     from dayu_widgets.qt import application
-    
+
     with application() as app:
         test = MDemo()
         dayu_theme.apply(test)

--- a/dayu_widgets/__main__.py
+++ b/dayu_widgets/__main__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Import future modules
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+# Import built-in modules
+import os
+import sys
+import importlib
+import signal
+
+# Import third-party modules
+from Qt import QtWidgets
+
+
+def main():
+    """
+    Main entry point for the dayu_widgets package when run as a module.
+    This function runs the demo application.
+    """
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    
+    # Add the parent directory to sys.path to ensure examples can be imported
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    
+    # Import the demo module
+    try:
+        from examples.demo import MDemo
+    except ImportError:
+        print("Error: Could not import the demo module. Make sure the examples directory is available.")
+        sys.exit(1)
+    
+    # Import local modules
+    from dayu_widgets import dayu_theme
+    from dayu_widgets.qt import application
+    
+    with application() as app:
+        test = MDemo()
+        dayu_theme.apply(test)
+        test.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,15 +20,17 @@ pip install dayu_widgets
 
 ## Run Demo
 
-After installation, you can run the demo application with the following commands:
+After installation, you can run the demo application with the following commands. Note that running the demo requires a Qt environment (like PySide2 or PyQt5):
 
 ```shell
-# Run as a Python module
+# Run as a Python module (requires PySide2 or PyQt5 to be installed)
 python -m dayu_widgets
 
-# Or use the command line tool
-uvx dayu_widgets
+# Or use the uvx command line tool (recommended, handles dependencies automatically)
+uvx --python 3.10 --with pyside2 dayu_widgets
 ```
+
+> **Note**: dayu_widgets is a Qt UI library, so running the demo requires a Qt environment. When using the `uvx` command, you can automatically handle Qt dependencies with the `--with pyside2` parameter.
 
 ## Usage
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,26 @@ The screenshots in docs used:
 * Dark: #fa8c16
 
 
+## Installation
+
+```shell
+pip install dayu_widgets
+```
+
+## Run Demo
+
+After installation, you can run the demo application with the following commands:
+
+```shell
+# Run as a Python module
+python -m dayu_widgets
+
+# Or use the command line tool
+uvx dayu_widgets
+```
+
+## Usage
+
 ```python
 import dayu_widgets
 ```

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -20,15 +20,17 @@ pip install dayu_widgets
 
 ## 运行示例程序
 
-安装后，可以通过以下命令直接运行示例程序：
+安装后，可以通过以下命令直接运行示例程序。注意，运行示例程序需要 Qt 环境（如 PySide2 或 PyQt5）：
 
 ```shell
-# 使用 Python 模块方式运行
+# 使用 Python 模块方式运行（需要先安装 PySide2 或 PyQt5）
 python -m dayu_widgets
 
-# 或者使用命令行工具运行
-uvx dayu_widgets
+# 使用 uvx 命令行工具运行（推荐方式，自动处理依赖）
+uvx --python 3.10 --with pyside2 dayu_widgets
 ```
+
+> **注意**：dayu_widgets 是一个 Qt 界面库，运行示例程序需要 Qt 环境。使用 `uvx` 命令时可以通过 `--with pyside2` 参数自动处理 Qt 依赖。
 
 ## 使用
 

--- a/docs/zh-cn/README.md
+++ b/docs/zh-cn/README.md
@@ -12,6 +12,26 @@
 * 暗色 #fa8c16
 
 
+## 安装
+
+```shell
+pip install dayu_widgets
+```
+
+## 运行示例程序
+
+安装后，可以通过以下命令直接运行示例程序：
+
+```shell
+# 使用 Python 模块方式运行
+python -m dayu_widgets
+
+# 或者使用命令行工具运行
+uvx dayu_widgets
+```
+
+## 使用
+
 ```python
 import dayu_widgets
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ singledispatch = {version = "^3.7.0", python = "2.7"}
 "Qt.py" = "^1.3.6"
 dayu-path = "^0.5.2"
 
+[tool.poetry.scripts]
+dayu_widgets = "dayu_widgets.__main__:main"
+
 [tool.poetry.dev-dependencies]
 pytest = {version = "^7.0.0", python = ">=3.6.0,<3.11"}
 PySide2 = {version = "^5.15.2", python = ">=3.6.0,<3.11"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 
 packages = [
     { include = "dayu_widgets" },
+    { include = "examples" },
 ]
 [tool.poetry.build]
 generate-setup-file = false


### PR DESCRIPTION
## 更新内容

本次更新添加了命令行入口点，使得用户可以通过简单的命令运行示例程序：

1. 创建了 `dayu_widgets/__main__.py` 文件，使得包可以作为模块运行
2. 在 `pyproject.toml` 中添加了命令行入口点配置
3. 在 `pyproject.toml` 中添加了 examples 目录到打包配置中
4. 更新了文档，添加了关于如何使用命令行工具的说明

## 使用方法

安装后，可以通过以下命令直接运行示例程序：

```shell
# 使用 Python 模块方式运行（需要先安装 PySide2 或 PyQt5）
python -m dayu_widgets

# 使用 uvx 命令行工具运行（推荐方式，自动处理依赖）
uvx --python 3.10 --with pyside2 dayu_widgets
```