### PR TITLE
fix: correct malformed JSON in .all-contributorsrc and add CI permissions

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -37,7 +37,7 @@
       "contributions": [
         "code"
       ]
-    },
+    }
   ],
   "skipCi": true
 }

--- a/.github/workflows/generate_llms_txt.yml
+++ b/.github/workflows/generate_llms_txt.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   generate-llms-txt:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## 🐛 Bug Fix

This PR fixes two critical issues:

### 1. Malformed JSON in .all-contributorsrc
- **Problem**: Trailing comma in contributors array caused JSON parsing error
- **Solution**: Removed the trailing comma after the last contributor object
- **Impact**: Fixes configuration file parsing for all-contributors tool

### 2. CI Permissions Issue for llms.txt Generation
- **Problem**: GitHub Actions workflow lacked proper permissions to push changes
- **Solution**: Added `contents: write` permission to the generate_llms_txt workflow
- **Impact**: Allows the workflow to successfully commit and push llms.txt updates

## 🧪 Testing
- [x] Validated JSON syntax using Node.js JSON parser
- [x] Verified workflow permissions configuration

## 📝 Changes
- Fixed JSON syntax error in `.all-contributorsrc`
- Added proper permissions to `.github/workflows/generate_llms_txt.yml`

Fixes the issues mentioned in the terminal output where:
1. Configuration file had malformed JSON at position 995
2. CI workflow failed due to protected branch restrictions